### PR TITLE
Support windowing system DPI scaling in OpenGL video backend

### DIFF
--- a/engine/sdl/opengl.c
+++ b/engine/sdl/opengl.c
@@ -283,6 +283,9 @@ int video_gl_set_mode(s_videomodes videomodes)
 		goto error;
 	}
 
+	// set proper viewport width/height for high-DPI support
+	SDL_GL_GetDrawableSize(window, &viewportWidth, &viewportHeight);
+
 	// set background to black
 	glClearColor(0.0, 0.0, 0.0, 0.0);
 	glClear(GL_COLOR_BUFFER_BIT);

--- a/engine/sdl/video.c
+++ b/engine/sdl/video.c
@@ -84,11 +84,24 @@ int SetVideoMode(int w, int h, int bpp, bool gl)
 	static int last_x = SDL_WINDOWPOS_UNDEFINED;
 	static int last_y = SDL_WINDOWPOS_UNDEFINED;
 
-	if(gl) flags |= SDL_WINDOW_OPENGL;
 	if(savedata.fullscreen) flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 
 	if(!(SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN_DESKTOP))
 		SDL_GetWindowPosition(window, &last_x, &last_y);
+
+	if (gl)
+	{
+		flags |= SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI;
+		SDL_SetHint(SDL_HINT_WINDOWS_DPI_SCALING, "1");
+	}
+	else
+	{
+		// The SDL video backend doesn't support high-quality (sharp bilinear) scaling,
+		// so it will produce bad results if it tries to scale by a fractional factor.
+		// The results are worse than what we get from upscaling with nearest-neighbor
+		// and letting the windowing system upscale the result.
+		SDL_SetHint(SDL_HINT_WINDOWS_DPI_SCALING, "0");
+	}
 
 	if(window && gl != last_gl)
 	{


### PR DESCRIPTION
This produces better results than the windowing system's scaling on top of our own, since we can do high-quality scaling in the OpenGL backend.

Works with Windows and Wayland, and should work for Mac as well.

# Pull Request

## General Description
Replace this text with a description of the changes and purpose. If the pull request resolves an issue, please cite the issue Example: Fixes #<issue number>.
